### PR TITLE
fix displaying interval in minutes

### DIFF
--- a/phoneClients/android/app/src/main/java/com/websmithing/gpstracker/GpsTrackerActivity.java
+++ b/phoneClients/android/app/src/main/java/com/websmithing/gpstracker/GpsTrackerActivity.java
@@ -216,7 +216,7 @@ public class GpsTrackerActivity extends ActionBarActivity {
 
     private void displayUserSettings() {
         SharedPreferences sharedPreferences = this.getSharedPreferences("com.websmithing.gpstracker.prefs", Context.MODE_PRIVATE);
-        int interval = sharedPreferences.getInt("intervalInMinutes", 1);
+        intervalInMinutes = sharedPreferences.getInt("intervalInMinutes", 1);
 
         switch (intervalInMinutes) {
             case 1:


### PR DESCRIPTION
interval in minutes preferences were being read but this was not being used properly to display in the radio settings.
